### PR TITLE
Improve error handling with error code 500 returned for bad request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
 		<dependency>
 			<groupId>gov.nasa.pds</groupId>
 			<artifactId>api</artifactId>
-			<version>0.2.1</version>
+			<version>0.2.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
 		<dependency>
 			<groupId>gov.nasa.pds</groupId>
 			<artifactId>api</artifactId>
-			<version>0.2.0</version>
+			<version>0.2.1</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/CollectionProductIterator.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/CollectionProductIterator.java
@@ -3,9 +3,11 @@ package gov.nasa.pds.api.engineering.elasticsearch.business;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import org.assertj.core.util.Arrays;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.RequestOptions;
@@ -132,15 +134,27 @@ public class CollectionProductIterator<T> implements Iterator<T> {
     
     
     private Iterator<String> initProductIterator() {
-    	ArrayList<String> productLidVidSet;
+    	ArrayList<String> productLidVidSet = null;
     	
     	if (!this.searchHitsIterator.hasNext()) { productLidVidSet = new ArrayList<String>(); }
     	else
     	{
+    		
     		SearchHit searchHit = this.searchHitsIterator.next();
-    		productLidVidSet = (ArrayList<String>) searchHit
+    		
+    		Object productLidVids = searchHit
     				.getSourceAsMap()
     				.get("product_lidvid");
+    		
+    		if (productLidVids instanceof String) {
+    			productLidVidSet = new ArrayList<String>() {{ add((String)productLidVids); }};
+    		}
+    		else if (productLidVids instanceof List<?>) {
+    			productLidVidSet = (ArrayList<String>)productLidVids;
+    		}
+    		else {
+    			log.error("product_lidvid attribute in index registry-refs type is unexpected " + productLidVids.getClass().getName());
+    		}
     	}
     	return productLidVidSet.iterator();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 springfox.documentation.swagger.v2.path=/api-docs
 server.contextPath=/
 server.port=8080
+server.use-forward-headers=true
 #spring.jackson.date-format=io.swagger.RFC3339DateFormat
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 debug=false


### PR DESCRIPTION
**Summary***
This pull request correct bug https://github.com/NASA-PDS/registry-api-service/issues/17 

**Test Data and/or Report**
The request can be tested on pds-gamma updated with this branch:

curl --location --request GET 'https://pds-gamma.jpl.nasa.gov/api/collections/urn:nasa:pds:insight_documents:document_mission::1.1/products?start=0&limit=10&fields=ops:Data_File_Info.ops:md5_checksum&only-summary=false
**Related Issues**
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.
-->

- fixes #17
       