### PR TITLE
Manage proxy for reference url generation, resolve url pds-gamma.jpl.nasa.gov/api/

### DIFF
--- a/src/main/java/gov/nasa/pds/api/engineering/configuration/HomeController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/configuration/HomeController.java
@@ -1,5 +1,6 @@
 package gov.nasa.pds.api.engineering.configuration;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -8,9 +9,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
  */
 @Controller
 public class HomeController {
+	
+	@Value("${server.contextPath}")
+	private String contextPath;
+	
     @RequestMapping(value = "/")
     public String index() {
-        System.out.println("swagger-ui.html");
-        return "redirect:swagger-ui.html";
+
+    	String contextPath = this.contextPath.endsWith("/")?this.contextPath:this.contextPath+"/";
+
+        System.out.println(contextPath+"swagger-ui.html");
+        return "redirect:"+contextPath+"swagger-ui.html";
     }
 }

--- a/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
@@ -60,14 +60,26 @@ public class WebMVCConfig implements WebMvcConfigurer {
 	   public void configurePathMatch(PathMatchConfigurer configurer) {
 		 // this is important to avoid that parameters (e.g lidvid) are truncated after .
 	       configurer.setUseSuffixPatternMatch(false);
+	      
 	   }
 	
 	
   /**
    * Setup a simple strategy: use all the defaults and return XML by default when not sure. 
  */
-  public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+  @SuppressWarnings("deprecation")
+public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
     configurer.defaultContentType(MediaType.APPLICATION_JSON);
+    
+    /*
+    // For path content negociation , .json. .xml ...
+    // that does not work on its own, I guess I also need to update the swagger definition
+    configurer.favorParameter(false).
+    ignoreAcceptHeader(false).
+    defaultContentType(MediaType.APPLICATION_JSON).
+    mediaType("xml", MediaType.APPLICATION_XML).
+    mediaType("json", MediaType.APPLICATION_JSON);
+    */
     
     
   }

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
@@ -146,7 +146,8 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
 	    	     	        
 	    	     	        if (!onlySummary) {
 	    	     	        	EntityProduct entityCollection = objectMapper.convertValue(sourceAsMap, EntityProduct.class);
-	    	     	        	Product collection = ElasticSearchUtil.ESentityProductToAPIProduct(entityCollection);
+
+	    	     	        	Product collection = ElasticSearchUtil.ESentityProductToAPIProduct(entityCollection, this.getBaseURL());
 	    	     	        	collection.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
 	    	         	        products.addDataItem(collection);
 	    	     	        }
@@ -301,8 +302,10 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
         				if (!onlySummary)
         				{
         					EntityProduct entityProduct = objectMapper.convertValue(sourceAsMap, EntityProduct.class);
-        					Product product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct);
-        					product.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
+
+        					Product product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct, this.getBaseURL());
+							product.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
+
         					products.addDataItem(product);
         				}
         			}

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
@@ -155,7 +155,7 @@ public class MyCollectionsApiController extends MyProductsApiBareController impl
 				  if (eProd != null) {
 		        	MyCollectionsApiController.log.info("request lidvdid: " + eProd.getLidVid() );
 		        	
-		    		Product product = ElasticSearchUtil.ESentityProductToAPIProduct(eProd);
+		    		Product product = ElasticSearchUtil.ESentityProductToAPIProduct(eProd, this.getBaseURL());
 				    		
 		    		Map<String, XMLMashallableProperyValue> filteredMapJsonProperties = ProductBusinessObject.getFilteredProperties(
 		    				eProd.getProperties(), 
@@ -258,8 +258,10 @@ public class MyCollectionsApiController extends MyProductsApiBareController impl
 	
 		        if (!summaryOnly) {
 	    	        EntityProduct entityProduct = objectMapper.convertValue(sourceAsMap, EntityProduct.class);
-	    	        Product product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct);
-	    	        product.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
+
+	    	        Product product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct, this.getBaseURL());
+					product.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
+
 	    	        products.addDataItem(product);
 		        }
 	    	}

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
@@ -157,8 +157,10 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
 	    			if (!summaryOnly)
 	    			{
 	    				EntityProduct entityProduct = objectMapper.convertValue(sourceAsMap, EntityProduct.class);
-	    				Product product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct);
-	    				product.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
+
+	    				Product product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct, this.getBaseURL());
+						product.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
+
 	    				products.addDataItem(product);
 	    			}
 	    		}
@@ -247,8 +249,10 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
 	
 		        if (!summaryOnly) {
 	    	        EntityProduct entityProduct = objectMapper.convertValue(sourceAsMap, EntityProduct.class);
-	    	        Product product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct);
-	    	        product.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
+
+	    	        Product product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct, this.getBaseURL());
+					product.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
+
 	    	        products.addDataItem(product);
 		        }
 	    	}

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/ElasticSearchUtil.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/ElasticSearchUtil.java
@@ -1,7 +1,16 @@
 package gov.nasa.pds.api.engineering.elasticsearch;
 
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.http.client.utils.URIBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -28,18 +37,37 @@ public class ElasticSearchUtil {
 			return elasticProperty.replace('/', '.');
 	 }
 	
-	static private void addReference (ArrayList<Reference> to, String ID, String baseURL)
+	static private void addReference (ArrayList<Reference> to, String ID, URL baseURL)
 	{
 		Reference reference = new Reference();
 		reference.setId(ID);
-		reference.setHref(baseURL + "/products/" + reference.getId());
+
+		String spec = "/products/" + reference.getId();
+		
+		try {
+			
+			URIBuilder uriBuilder = new URIBuilder(baseURL.toURI());
+			URI uri = uriBuilder.setPath(uriBuilder.getPath() + spec)
+			          .build()
+			          .normalize();
+			
+			
+			reference.setHref(uri.toString());
+			
+		} catch (URISyntaxException e) {
+			log.warn("Unable to create external URL for reference ");
+			e.printStackTrace();
+			reference.setHref(spec);
+		}
+		
 		to.add(reference);
 	}
 	
 	
 	static private Product addPropertiesFromESEntity(
 			Product product, 
-			EntityProduct ep
+			EntityProduct ep,
+			URL baseURL
 			) {
 		product.setId(ep.getLidVid());
 		product.setType(ep.getProductClass());
@@ -63,7 +91,7 @@ public class ElasticSearchUtil {
 		ArrayList<Reference> observationSystemComponent = new ArrayList<Reference>();
 		ArrayList<Reference> targets = new ArrayList<Reference>();
 		Metadata meta = new Metadata();
-		String baseURL = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+		//String baseURL = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
 
 		String version = ep.getVersion();
 		if (version != null) {
@@ -101,23 +129,21 @@ public class ElasticSearchUtil {
 
 	}
 	
-	static public ProductWithXmlLabel ESentityProductToAPIProduct(EntitytProductWithBlob ep) {
+	static public ProductWithXmlLabel ESentityProductToAPIProduct(EntitytProductWithBlob ep, URL baseURL) {
 		ElasticSearchUtil.log.info("convert ES object to API object with XML label");
 		ProductWithXmlLabel product = new ProductWithXmlLabel();
 		product.setLabelXml(ep.getPDS4XML());
-		return (ProductWithXmlLabel)addPropertiesFromESEntity(product, ep);
+		return (ProductWithXmlLabel)addPropertiesFromESEntity(product, ep, baseURL);
 		
 	}
 	
 
-	static public Product ESentityProductToAPIProduct(EntityProduct ep) {
-		
-	
+	static public Product ESentityProductToAPIProduct(EntityProduct ep, URL baseURL) {
 		ElasticSearchUtil.log.info("convert ES object to API object without XML label");
 		
 		Product product = new Product();
 		
-		return addPropertiesFromESEntity(product, ep);
+		return addPropertiesFromESEntity(product, ep, baseURL);
 		
 				
 	}

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/ProductBusinessObject.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/ProductBusinessObject.java
@@ -1,6 +1,7 @@
 package gov.nasa.pds.api.engineering.elasticsearch.business;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -178,13 +179,17 @@ public class ProductBusinessObject {
 	    }
 	    
 	   
-	   public Product getProduct(String lidvid) throws IOException {
-		   return this.getProduct(lidvid, null);
+	   public Product getProduct(String lidvid, URL baseURL) throws IOException {
+		   return this.getProduct(lidvid, baseURL, null);
 	   }
 	   
 	   
+<<<<<<< HEAD
 	   @SuppressWarnings("unchecked")
 	public Product getProduct(String lidvid, @Nullable List<String> fields) throws IOException {
+=======
+	   public Product getProduct(String lidvid, URL baseURL, @Nullable List<String> fields) throws IOException {
+>>>>>>> manage baseUrl from proxy, manage context path for swagger doc
 		   GetRequest getProductRequest = this.searchRequestBuilder.getGetProductRequest(lidvid, false);
 		   
 		   GetResponse getResponse = null;
@@ -207,7 +212,7 @@ public class ProductBusinessObject {
 	       		
 	       		entityProduct = this.objectMapper.convertValue(sourceAsMap, EntityProduct.class);
 	       		
-	       		Product product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct);
+	       		Product product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct, baseURL);
 	       	
 	       		product.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
 	       		
@@ -220,13 +225,13 @@ public class ProductBusinessObject {
 	   }
 	   
 	   
-	   public ProductWithXmlLabel getProductWithXml(String lidvid)  throws IOException {
-		   return this.getProductWithXml(lidvid, null);
+	   public ProductWithXmlLabel getProductWithXml(String lidvid, URL baseURL)  throws IOException {
+		   return this.getProductWithXml(lidvid, baseURL, null);
 	   }
 	   
 	   // TODO make the method more generic by having the name of the class we want to cast the object into instead of a boolean, the code will be more neat also
 	   @SuppressWarnings("unchecked")
-	public ProductWithXmlLabel getProductWithXml(String lidvid, @Nullable List<String> field) throws IOException {
+	   public ProductWithXmlLabel getProductWithXml(String lidvid, URL baseURL, @Nullable List<String> field) throws IOException {
 		   
 		   GetRequest getProductRequest = this.searchRequestBuilder.getGetProductRequest(lidvid, true);
 		   
@@ -257,6 +262,7 @@ public class ProductBusinessObject {
 		       		
 		       		entityProduct = this.objectMapper.convertValue(sourceAsMap, EntitytProductWithBlob.class);
 		       		
+
 		       		ProductWithXmlLabel product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct);    		
 		       		product.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
 		       	

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/ProductBusinessObject.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/ProductBusinessObject.java
@@ -184,12 +184,10 @@ public class ProductBusinessObject {
 	   }
 	   
 	   
-<<<<<<< HEAD
+
 	   @SuppressWarnings("unchecked")
-	public Product getProduct(String lidvid, @Nullable List<String> fields) throws IOException {
-=======
 	   public Product getProduct(String lidvid, URL baseURL, @Nullable List<String> fields) throws IOException {
->>>>>>> manage baseUrl from proxy, manage context path for swagger doc
+
 		   GetRequest getProductRequest = this.searchRequestBuilder.getGetProductRequest(lidvid, false);
 		   
 		   GetResponse getResponse = null;
@@ -263,7 +261,7 @@ public class ProductBusinessObject {
 		       		entityProduct = this.objectMapper.convertValue(sourceAsMap, EntitytProductWithBlob.class);
 		       		
 
-		       		ProductWithXmlLabel product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct);    		
+		       		ProductWithXmlLabel product = ElasticSearchUtil.ESentityProductToAPIProduct(entityProduct, baseURL);    		
 		       		product.setProperties((Map<String, PropertyArrayValues>)(Map<String, ?>)filteredMapJsonProperties);
 		       	
 		       		return product;


### PR DESCRIPTION
**Summary***
The change enable to generate the reference url generation when the API is behind a proxy.

Now also the url pds-gamma.jpl.nasa.gov/api/ revolves to pds-gamma.jpl.nasa.gov/api/swagger-ui.html (before it resolved to a 404 error or something)

**Test Data and/or Report**
The branch has been deployed on pds-gamma

Test http reference with url:
curl --location --request GET 'https://pds-gamma.jpl.nasa.gov/api/products?limit=100'

Test /api/ url in a browser: https://pds-gamma.jpl.nasa.gov/api or https://pds-gamma.jpl.nasa.gov/api/


**Related Issues**
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.
-->
  
* fixes #10 
* fixes #39 

    