### PR TITLE
pds-api #91 : do not support html/xml and force JSON

### DIFF
--- a/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
@@ -46,6 +46,7 @@ public class WebMVCConfig implements WebMvcConfigurer {
 	/**
 	 * Setup a simple strategy: use all the defaults and return XML by default when not sure. 
 	 */
+	@Override
 	@SuppressWarnings("deprecation")
 	public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
 		configurer.defaultContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
@@ -1,40 +1,21 @@
 package gov.nasa.pds.api.engineering.configuration;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
-import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
-import org.springframework.http.converter.xml.SourceHttpMessageConverter;
-import org.springframework.web.accept.ContentNegotiationManager;
-import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.view.ContentNegotiatingViewResolver;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-
-import gov.nasa.pds.model.Product;
-import gov.nasa.pds.model.Products;
 import gov.nasa.pds.api.engineering.serializer.Pds4JsonProductSerializer;
 import gov.nasa.pds.api.engineering.serializer.Pds4XmlProductSerializer;
-import gov.nasa.pds.api.engineering.serializer.Pds4XmlProductsSerializer;
 import gov.nasa.pds.api.engineering.serializer.XmlProductSerializer;
 
 @Configuration
@@ -56,52 +37,41 @@ public class WebMVCConfig implements WebMvcConfigurer {
 	}
 	
 	
-	 @Override
-	   public void configurePathMatch(PathMatchConfigurer configurer) {
-		 // this is important to avoid that parameters (e.g lidvid) are truncated after .
-	       configurer.setUseSuffixPatternMatch(false);
-	      
-	   }
-	
-	
-  /**
-   * Setup a simple strategy: use all the defaults and return XML by default when not sure. 
- */
-  @SuppressWarnings("deprecation")
-public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
-    configurer.defaultContentType(MediaType.APPLICATION_JSON);
-    
-    /*
-    // For path content negociation , .json. .xml ...
-    // that does not work on its own, I guess I also need to update the swagger definition
-    configurer.favorParameter(false).
-    ignoreAcceptHeader(false).
-    defaultContentType(MediaType.APPLICATION_JSON).
-    mediaType("xml", MediaType.APPLICATION_XML).
-    mediaType("json", MediaType.APPLICATION_JSON);
-    */
-    
-    
-  }
-  
-  
-  @Override
-  public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
-   
-	  WebMVCConfig.log.info("Number of converters available " + Integer.toString(converters.size()));
-	  converters.add(new Pds4JsonProductSerializer());
-	  converters.add(new Pds4XmlProductSerializer()); // Product class, application/pds4+xml
-	  converters.add(new XmlProductSerializer()); // Product class, application/xml
-	  converters.add(new Jaxb2RootElementHttpMessageConverter()); // other classes, application/xml
-	  
-	  
-	  
-  }
-  
+	@Override
+	public void configurePathMatch(PathMatchConfigurer configurer) {
+		// this is important to avoid that parameters (e.g lidvid) are truncated after .
+		configurer.setUseSuffixPatternMatch(false);  
+	}
 
-  
-  
-  
+	/**
+	 * Setup a simple strategy: use all the defaults and return XML by default when not sure. 
+	 */
+	@SuppressWarnings("deprecation")
+	public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+		configurer.defaultContentType(MediaType.APPLICATION_JSON);
 
-  
+		/*
+    	// For path content negotiation , .json. .xml ...
+    	// that does not work on its own, I guess I also need to update the swagger definition
+    	configurer.favorParameter(false).
+    	ignoreAcceptHeader(false).
+    	defaultContentType(MediaType.APPLICATION_JSON).
+    	mediaType("xml", MediaType.APPLICATION_XML).
+    	mediaType("json", MediaType.APPLICATION_JSON);
+		 */ 
+	}
+
+	@Override
+	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+		WebMVCConfig.log.info("Number of converters available " + Integer.toString(converters.size()));
+		converters.add(new Pds4JsonProductSerializer());
+		converters.add(new Pds4XmlProductSerializer()); // Product class, application/pds4+xml
+		converters.add(new XmlProductSerializer()); // Product class, application/xml
+
+		/* JILT: never want to see html/xml again!
+		 * To find the other places that need to also be changed if this is ever desired again,
+		 * search the code for JILT. Should be unique enough to not cross over. 
+	  	converters.add(new Jaxb2RootElementHttpMessageConverter()); // other classes, application/xml
+		 */
+	}  
 }

--- a/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
@@ -67,11 +67,11 @@ public class WebMVCConfig implements WebMvcConfigurer {
 		WebMVCConfig.log.info("Number of converters available " + Integer.toString(converters.size()));
 		converters.add(new Pds4JsonProductSerializer());
 		converters.add(new Pds4XmlProductSerializer()); // Product class, application/pds4+xml
-		converters.add(new XmlProductSerializer()); // Product class, application/xml
 
 		/* JILT: never want to see html/xml again!
 		 * To find the other places that need to also be changed if this is ever desired again,
 		 * search the code for JILT. Should be unique enough to not cross over. 
+		converters.add(new XmlProductSerializer()); // Product class, application/xml
 	  	converters.add(new Jaxb2RootElementHttpMessageConverter()); // other classes, application/xml
 		 */
 	}  

--- a/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
@@ -1,40 +1,21 @@
 package gov.nasa.pds.api.engineering.configuration;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
-import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
-import org.springframework.http.converter.xml.SourceHttpMessageConverter;
-import org.springframework.web.accept.ContentNegotiationManager;
-import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.view.ContentNegotiatingViewResolver;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-
-import gov.nasa.pds.model.Product;
-import gov.nasa.pds.model.Products;
 import gov.nasa.pds.api.engineering.serializer.Pds4JsonProductSerializer;
 import gov.nasa.pds.api.engineering.serializer.Pds4XmlProductSerializer;
-import gov.nasa.pds.api.engineering.serializer.Pds4XmlProductsSerializer;
 import gov.nasa.pds.api.engineering.serializer.XmlProductSerializer;
 
 @Configuration
@@ -56,52 +37,42 @@ public class WebMVCConfig implements WebMvcConfigurer {
 	}
 	
 	
-	 @Override
-	   public void configurePathMatch(PathMatchConfigurer configurer) {
-		 // this is important to avoid that parameters (e.g lidvid) are truncated after .
-	       configurer.setUseSuffixPatternMatch(false);
-	      
-	   }
-	
-	
-  /**
-   * Setup a simple strategy: use all the defaults and return XML by default when not sure. 
- */
-  @SuppressWarnings("deprecation")
-public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
-    configurer.defaultContentType(MediaType.APPLICATION_JSON);
-    
-    /*
-    // For path content negociation , .json. .xml ...
-    // that does not work on its own, I guess I also need to update the swagger definition
-    configurer.favorParameter(false).
-    ignoreAcceptHeader(false).
-    defaultContentType(MediaType.APPLICATION_JSON).
-    mediaType("xml", MediaType.APPLICATION_XML).
-    mediaType("json", MediaType.APPLICATION_JSON);
-    */
-    
-    
-  }
-  
-  
-  @Override
-  public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
-   
-	  WebMVCConfig.log.info("Number of converters available " + Integer.toString(converters.size()));
-	  converters.add(new Pds4JsonProductSerializer());
-	  converters.add(new Pds4XmlProductSerializer()); // Product class, application/pds4+xml
-	  converters.add(new XmlProductSerializer()); // Product class, application/xml
-	  converters.add(new Jaxb2RootElementHttpMessageConverter()); // other classes, application/xml
-	  
-	  
-	  
-  }
-  
+	@Override
+	public void configurePathMatch(PathMatchConfigurer configurer) {
+		// this is important to avoid that parameters (e.g lidvid) are truncated after .
+		configurer.setUseSuffixPatternMatch(false);  
+	}
 
-  
-  
-  
+	/**
+	 * Setup a simple strategy: use all the defaults and return XML by default when not sure. 
+	 */
+	@Override
+	@SuppressWarnings("deprecation")
+	public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+		configurer.defaultContentType(MediaType.APPLICATION_JSON);
 
-  
+		/*
+    	// For path content negotiation , .json. .xml ...
+    	// that does not work on its own, I guess I also need to update the swagger definition
+    	configurer.favorParameter(false).
+    	ignoreAcceptHeader(false).
+    	defaultContentType(MediaType.APPLICATION_JSON).
+    	mediaType("xml", MediaType.APPLICATION_XML).
+    	mediaType("json", MediaType.APPLICATION_JSON);
+		 */ 
+	}
+
+	@Override
+	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+		WebMVCConfig.log.info("Number of converters available " + Integer.toString(converters.size()));
+		converters.add(new Pds4JsonProductSerializer());
+		converters.add(new Pds4XmlProductSerializer()); // Product class, application/pds4+xml
+		converters.add(new XmlProductSerializer()); // Product class, application/xml
+
+		/* JILT: never want to see html/xml again!
+		 * To find the other places that need to also be changed if this is ever desired again,
+		 * search the code for JILT. Should be unique enough to not cross over. 
+	  	converters.add(new Jaxb2RootElementHttpMessageConverter()); // other classes, application/xml
+		 */
+	}  
 }

--- a/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4JsonProductSerializer.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4JsonProductSerializer.java
@@ -1,32 +1,16 @@
 package gov.nasa.pds.api.engineering.serializer;
 
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamWriter;
-import javax.xml.transform.Result;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpInputMessage;
-import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.util.StreamUtils;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gov.nasa.pds.api.model.xml.ProductWithXmlLabel;
-import gov.nasa.pds.model.Product;
-
-
 
 public class Pds4JsonProductSerializer extends MappingJackson2HttpMessageConverter {
 	
@@ -38,13 +22,12 @@ public class Pds4JsonProductSerializer extends MappingJackson2HttpMessageConvert
 		
 		List<MediaType> supportMediaTypes = new ArrayList<MediaType>();
 		supportMediaTypes.add(MediaType.APPLICATION_JSON);
+		// JILT: need to remove the media types below if http/xml is once again desired
+		supportMediaTypes.addAll(Arrays.asList(MediaType.APPLICATION_XML, MediaType.TEXT_XML, new MediaType("application", "*+xml")));
 		this.setSupportedMediaTypes(supportMediaTypes);
-		
+
 		ObjectMapper mapper = new ObjectMapper();
 	    mapper.setSerializationInclusion(Include.NON_NULL);
-	    this.setObjectMapper(mapper);
-	     
+	    this.setObjectMapper(mapper);    
 	}
-	
-
 }

--- a/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4JsonProductSerializer.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4JsonProductSerializer.java
@@ -1,7 +1,6 @@
 package gov.nasa.pds.api.engineering.serializer;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -22,8 +21,6 @@ public class Pds4JsonProductSerializer extends MappingJackson2HttpMessageConvert
 		
 		List<MediaType> supportMediaTypes = new ArrayList<MediaType>();
 		supportMediaTypes.add(MediaType.APPLICATION_JSON);
-		// JILT: need to remove the media types below if http/xml is once again desired
-		supportMediaTypes.addAll(Arrays.asList(MediaType.APPLICATION_XML, MediaType.TEXT_XML, new MediaType("application", "*+xml")));
 		this.setSupportedMediaTypes(supportMediaTypes);
 
 		ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
**Summary***
Removed the XML to HTML/XML converter.

**Test Data and/or Report**
Visited `http://localhost:8080/products` with results attached as image. It generates an error deep in Apache and SpringBoard tools:

```
2021-08-31 18:06:38.557 DEBUG 53 --- [0.3-8080-exec-1] o.s.w.s.m.m.a.HttpEntityMethodProcessor  : Using 'application/xml;q=0.9', given [text/html, application/xhtml+xml, image/webp, application/xml;q=0.9, */*;q=0.8] and supported [application/json, application/xml]
2021-08-31 18:06:38.559  WARN 53 --- [0.3-8080-exec-1] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.http.converter.HttpMessageNotWritableException: No converter for [class gov.nasa.pds.model.Products] with preset Content-Type 'null']
2021-08-31 18:06:38.559 DEBUG 53 --- [0.3-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Completed 500 INTERNAL_SERVER_ERROR
2021-08-31 18:06:38.561 DEBUG 53 --- [0.3-8080-exec-1] o.a.c.c.C.[Tomcat].[localhost]           : Processing ErrorPage[errorCode=0, location=/error]
2021-08-31 18:06:38.564 DEBUG 53 --- [0.3-8080-exec-1] o.s.web.servlet.DispatcherServlet        : "ERROR" dispatch for GET "/error", parameters={}
2021-08-31 18:06:38.564 DEBUG 53 --- [0.3-8080-exec-1] pertySourcedRequestMappingHandlerMapping : looking up handler for path: /error
2021-08-31 18:06:38.566 DEBUG 53 --- [0.3-8080-exec-1] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped to org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController#errorHtml(HttpServletRequest, HttpServletResponse)
2021-08-31 18:06:38.578 DEBUG 53 --- [0.3-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Exiting from "ERROR" dispatch, status 500
```

It looks as though a different and more informative error could be generated but this should be a different ticket because this error will also cover application/pickle as well as application/xml etc.

On firefox, the error looks like this (not informative):

![error_msg](https://user-images.githubusercontent.com/1130658/131555383-d57362e7-0f7f-4cd1-a8fd-fefc04eb71e3.png)


**Related Issues**
None