### PR TITLE
pds-api 68 : Add hits and took

### DIFF
--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
@@ -50,16 +50,16 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     	return this.getProductResponseEntity(lidvid);
     }
 
+    @Override
     public ResponseEntity<Products> getBundles(
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
             @ApiParam(value = "search query, complex query uses eq,ne,gt,ge,lt,le,(,),not,and,or. Properties are named as in 'properties' attributes, literals are strings between \" or numbers. Detailed query specification is available at https://bit.ly/393i1af") @Valid @RequestParam(value = "q", required = false) String q,
-            @ApiParam(value = "keyword search query") @Valid @RequestParam(value = "keyword", required = false) String keyword,
             @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
             @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
             @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
     {
-        return this.getProductsResponseEntity(q, keyword, start, limit, fields, sort, onlySummary);
+        return this.getProductsResponseEntity(q, null, start, limit, fields, sort, onlySummary);
     }    
     
     

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
@@ -98,6 +98,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     
     private Products getCollectionChildren(String lidvid, int start, int limit, List<String> fields, List<String> sort, boolean onlySummary) throws IOException
     {
+    	long begin = System.currentTimeMillis();
 		if (!lidvid.contains("::") && !lidvid.endsWith(":")) lidvid = this.productBO.getLatestLidVidFromLid(lidvid);
     	MyBundlesApiController.log.info("request bundle lidvid, collections children: " + lidvid);
 
@@ -108,9 +109,11 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
 
     	if (sort == null) { sort = Arrays.asList(); }
 
-    	summary.setStart(start);
+    	summary.setHits(clidvids.size());
     	summary.setLimit(limit);
     	summary.setSort(sort);
+    	summary.setStart(start);
+    	summary.setTook(-1);
     	products.setSummary(summary);
 
     	if (0 < clidvids.size())
@@ -122,6 +125,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     	else MyBundlesApiController.log.warn ("Did not find any collections for bundle lidvid: " + lidvid);
 
     	summary.setProperties(new ArrayList<String>(uniqueProperties));
+    	summary.setTook((int)(System.currentTimeMillis() - begin));
     	return products;	
     }
 
@@ -181,6 +185,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
 
 	private Products getProductChildren(String lidvid, int start, int limit, List<String> fields, List<String> sort, boolean onlySummary) throws IOException
     {
+		long begin = System.currentTimeMillis();
     	if (!lidvid.contains("::")) lidvid = this.productBO.getLatestLidVidFromLid(lidvid);
     	MyBundlesApiController.log.info("request bundle lidvid, children of products: " + lidvid);
 
@@ -194,9 +199,11 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
 
     	if (sort == null) { sort = Arrays.asList(); }
 
-    	summary.setStart(start);
+    	summary.setHits(-1);
     	summary.setLimit(limit);
     	summary.setSort(sort);
+    	summary.setStart(start);
+    	summary.setTook(-1);
     	products.setSummary(summary);
 
     	if (0 < clidvids.size())
@@ -222,8 +229,9 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     			if (start <= iteration || start < iteration+wlidvids.size())
     			{ plidvids.addAll(wlidvids.subList(start <= iteration ? 0 : start-iteration, wlidvids.size())); }
 
-    			if (limit <= plidvids.size()) { break; }
-    			else { iteration = iteration + wlidvids.size() + wsize; }
+    			//if (limit <= plidvids.size()) { break; }
+    			//else { iteration = iteration + wlidvids.size() + wsize; }
+    			iteration = iteration + wlidvids.size() + wsize;
     		}
     	}
     	else MyBundlesApiController.log.warn ("Did not find any collections for bundle lidvid: " + lidvid);
@@ -237,7 +245,9 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     	}
     	else MyBundlesApiController.log.warn ("Did not find any products for bundle lidvid: " + lidvid);
 
+    	summary.setHits(iteration);
     	summary.setProperties(new ArrayList<String>(uniqueProperties));
+    	summary.setTook((int)(System.currentTimeMillis() - begin));
     	return products;	
     }
 }

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
@@ -50,16 +50,16 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     	return this.getProductResponseEntity(lidvid);
     }
 
-    @Override
     public ResponseEntity<Products> getBundles(
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
             @ApiParam(value = "search query, complex query uses eq,ne,gt,ge,lt,le,(,),not,and,or. Properties are named as in 'properties' attributes, literals are strings between \" or numbers. Detailed query specification is available at https://bit.ly/393i1af") @Valid @RequestParam(value = "q", required = false) String q,
+            @ApiParam(value = "keyword search query") @Valid @RequestParam(value = "keyword", required = false) String keyword,
             @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
             @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
             @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
     {
-        return this.getProductsResponseEntity(q, null, start, limit, fields, sort, onlySummary);
+        return this.getProductsResponseEntity(q, keyword, start, limit, fields, sort, onlySummary);
     }    
     
     

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
@@ -99,8 +99,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     private Products getCollectionChildren(String lidvid, int start, int limit, List<String> fields, List<String> sort, boolean onlySummary) throws IOException,LidVidNotFoundException
     {
     	long begin = System.currentTimeMillis();
-  		if (!lidvid.contains("::") && !lidvid.endsWith(":")) lidvid = this.productBO.getLatestLidVidFromLid(lidvid);
-
+	lidvid = this.productBO.getLatestLidVidFromLid(lidvid);
     	MyBundlesApiController.log.info("request bundle lidvid, collections children: " + lidvid);
 
     	HashSet<String> uniqueProperties = new HashSet<String>();
@@ -194,9 +193,8 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
 
 	private Products getProductChildren(String lidvid, int start, int limit, List<String> fields, List<String> sort, boolean onlySummary) throws IOException,LidVidNotFoundException
     {
-  		long begin = System.currentTimeMillis();
-    	if (!lidvid.contains("::")) lidvid = this.productBO.getLatestLidVidFromLid(lidvid);
-
+  	long begin = System.currentTimeMillis();
+    	lidvid = this.productBO.getLatestLidVidFromLid(lidvid);
     	MyBundlesApiController.log.info("request bundle lidvid, children of products: " + lidvid);
 
     	int iteration=0,wsize=0;

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
@@ -53,16 +53,17 @@ public class MyCollectionsApiController extends MyProductsApiBareController impl
     	return this.getProductResponseEntity(lidvid);
     }
 
-    @Override
+
     public ResponseEntity<Products> getCollection(
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
             @ApiParam(value = "search query, complex query uses eq,ne,gt,ge,lt,le,(,),not,and,or. Properties are named as in 'properties' attributes, literals are strings between \" or numbers. Detailed query specification is available at https://bit.ly/393i1af") @Valid @RequestParam(value = "q", required = false) String q,
+            @ApiParam(value = "keyword search query") @Valid @RequestParam(value = "keyword", required = false) String keyword,
             @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
             @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
             @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
     {
-        return this.getProductsResponseEntity(q, null, start, limit, fields, sort, onlySummary);
+        return this.getProductsResponseEntity(q, keyword, start, limit, fields, sort, onlySummary);
     }    
 
     

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
@@ -53,17 +53,16 @@ public class MyCollectionsApiController extends MyProductsApiBareController impl
     	return this.getProductResponseEntity(lidvid);
     }
 
-
+    @Override
     public ResponseEntity<Products> getCollection(
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
             @ApiParam(value = "search query, complex query uses eq,ne,gt,ge,lt,le,(,),not,and,or. Properties are named as in 'properties' attributes, literals are strings between \" or numbers. Detailed query specification is available at https://bit.ly/393i1af") @Valid @RequestParam(value = "q", required = false) String q,
-            @ApiParam(value = "keyword search query") @Valid @RequestParam(value = "keyword", required = false) String keyword,
             @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
             @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
             @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
     {
-        return this.getProductsResponseEntity(q, keyword, start, limit, fields, sort, onlySummary);
+        return this.getProductsResponseEntity(q, null, start, limit, fields, sort, onlySummary);
     }    
 
     

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiBareController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiBareController.java
@@ -113,8 +113,10 @@ protected void fillProductsFromLidvids (Products products, HashSet<String> uniqu
     }
 
     @SuppressWarnings("unchecked")
-	protected Products getProducts(String q, String keyword, int start, int limit, List<String> fields, List<String> sort, boolean onlySummary) throws IOException {
-    		        	
+	protected Products getProducts(String q, String keyword, int start, int limit, List<String> fields, List<String> sort, boolean onlySummary) throws IOException
+    {
+    	long begin = System.currentTimeMillis();
+
     	SearchRequest searchRequest = this.searchRequestBuilder.getSearchProductsRequest(q, keyword, fields, start, limit, this.presetCriteria);
     	
     	SearchResponse searchResponse = this.esRegistryConnection.getRestHighLevelClient().search(searchRequest, 
@@ -126,10 +128,12 @@ protected void fillProductsFromLidvids (Products products, HashSet<String> uniqu
     	
       	Summary summary = new Summary();
 
+      	summary.setHits(-1);
+    	summary.setLimit(limit);
       	summary.setQ((q != null)?q:"" );
     	summary.setStart(start);
-    	summary.setLimit(limit);
-    	
+    	summary.setTook(-1);
+
     	if (sort == null) {
     		sort = Arrays.asList();
     	}	
@@ -138,7 +142,7 @@ protected void fillProductsFromLidvids (Products products, HashSet<String> uniqu
     	products.setSummary(summary);
     	
     	if (searchResponse != null) {
-    		
+    		summary.setHits((int)searchResponse.getHits().getTotalHits().value);
     		for (SearchHit searchHit : searchResponse.getHits()) {
     	        Map<String, Object> sourceAsMap = searchHit.getSourceAsMap();
     	        
@@ -170,7 +174,7 @@ protected void fillProductsFromLidvids (Products products, HashSet<String> uniqu
     	
     	
     	summary.setProperties(new ArrayList<String>(uniqueProperties));
-    	
+    	summary.setTook((int)(System.currentTimeMillis() - begin));
     	return products;
     }
     

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
@@ -44,17 +44,16 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
     	super(objectMapper, request);
     }
     
-   
+   @Override
     public ResponseEntity<Products> products(
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
             @ApiParam(value = "search query") @Valid @RequestParam(value = "q", required = false) String q,
-            @ApiParam(value = "keyword search query") @Valid @RequestParam(value = "keyword", required = false) String keyword,
             @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
             @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
             @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
     {
-        return this.getProductsResponseEntity(q, keyword, start, limit, fields, sort, onlySummary);
+        return this.getProductsResponseEntity(q, null, start, limit, fields, sort, onlySummary);
     }
     
      
@@ -205,4 +204,5 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
     	summary.setProperties(new ArrayList<String>(uniqueProperties));
     	return products;
 	}
+
 }

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
@@ -44,16 +44,17 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
     	super(objectMapper, request);
     }
     
-   @Override
+   
     public ResponseEntity<Products> products(
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
             @ApiParam(value = "search query") @Valid @RequestParam(value = "q", required = false) String q,
+            @ApiParam(value = "keyword search query") @Valid @RequestParam(value = "keyword", required = false) String keyword,
             @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
             @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
             @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
     {
-        return this.getProductsResponseEntity(q, null, start, limit, fields, sort, onlySummary);
+        return this.getProductsResponseEntity(q, keyword, start, limit, fields, sort, onlySummary);
     }
     
      
@@ -213,5 +214,4 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
     	summary.setTook((int)(System.currentTimeMillis() - begin));
     	return products;
 	}
-
 }

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/ElasticSearchUtil.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/ElasticSearchUtil.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +24,7 @@ import gov.nasa.pds.model.Metadata;
 import gov.nasa.pds.api.model.xml.ProductWithXmlLabel;
 import gov.nasa.pds.model.Product;
 import gov.nasa.pds.model.Reference;
+import gov.nasa.pds.model.Summary;
 
 public class ElasticSearchUtil {
 	
@@ -144,11 +146,13 @@ public class ElasticSearchUtil {
 		return addPropertiesFromESEntity(product, ep, baseURL);
 	}
 	
-	static public List<Map<String,Object>> collate (RestHighLevelClient client, SearchRequest request) throws IOException
+	static public List<Map<String,Object>> collate (RestHighLevelClient client, SearchRequest request, Summary summary) throws IOException
 	{
     	List<Map<String,Object>> results = new ArrayList<Map<String,Object>>();
-
-    	for (SearchHit hit : client.search(request, RequestOptions.DEFAULT).getHits())
+    	SearchHits findings = client.search(request, RequestOptions.DEFAULT).getHits(); 
+    	
+    	summary.hits((int)findings.getTotalHits().value);
+    	for (SearchHit hit : findings)
     	{
     		results.add(hit.getSourceAsMap());
     	}


### PR DESCRIPTION
**Summary***
Added hits and took to the swagger. Adjusted the logic to fill in these items.

**Test Data and/or Report**

Using a standard curl, the results now show 'hits' and 'took':

```
$ curl --header 'Accept: application/json' "http://localhost:8080/bundles/urn:nasa:pds:izenberg_pdart14_meap::1.0/products?limit=1&start=0&fields=ops:Label_File_Info.ops:md5_checksum&only-summary=true"

{"summary":{

  "hits":65, "took":168,

"start":0,"limit":1,"sort":[],"properties":["vid","product_class","ops:Label_File_Info/ops:md5_checksum","ref_lid_instrument_host","ref_lid_investigation","lidvid","ref_lid_target","title","ref_lid_instrument","ops:Label_File_Info/ops:file_ref"]}}
```
Stating that there are 65 possibilities (hits) and it the processing time was 168 ms (took).


**Related Issues**

    * fixes issues in [pds-api] repo:
        - [68](https://github.com/NASA-PDS/pds-api/issues/68)
        - [87](https://github.com/nasa-pds/pds-api/issues/87)
        - [105](https://github.com/NASA-PDS/pds-api/issues/105)
        - #31 (actually this repo)