### PR TITLE
Fixed boolean operators (and, or) and introduced wildcard() function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
 		<dependency>
 			<groupId>gov.nasa.pds</groupId>
 			<artifactId>api-search-query-lexer</artifactId>
-			<version>0.2.0</version>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiBareController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiBareController.java
@@ -185,7 +185,7 @@ public class MyProductsApiBareController {
             List<String> fields, List<String> sort, boolean onlySummary)
     {
         String accept = this.request.getHeader("Accept");
-        log.info("accept value is " + accept);
+        log.debug("accept value is " + accept);
         if ((accept != null && 
                 (accept.contains("application/json")
                         || accept.contains("application/pds4+json")
@@ -236,7 +236,7 @@ public class MyProductsApiBareController {
     protected ResponseEntity<Object> getAllProductsResponseEntity(String lidvid, int start, int limit)
     {
         String accept = this.request.getHeader("Accept");
-        log.info("accept value is " + accept);
+        log.debug("accept value is " + accept);
         if ((accept != null && (accept.contains("application/json") || accept.contains("text/html")
                 || accept.contains("application/xml") || accept.contains("*/*"))) || (accept == null))
         {
@@ -370,10 +370,9 @@ public class MyProductsApiBareController {
                 baseURL = new URL(this.context.getScheme(), this.context.getServerName(), this.context.getServerPort(), this.contextPath);
             }
             
-            MyProductsApiBareController.log.info("baseUrl is " + baseURL.toString());
+            log.debug("baseUrl is " + baseURL.toString());
             return baseURL;
             
-
         } catch (MalformedURLException e) {
             log.error("Server URL was not retrieved");
             return null;

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/Antlr4SearchListener.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/Antlr4SearchListener.java
@@ -118,25 +118,27 @@ public class Antlr4SearchListener extends SearchBaseListener
 	 @Override
 	 public void enterComparison(SearchParser.ComparisonContext ctx)
 	 {
-		 this.wildcard = ctx.VALUE() != null && (ctx.VALUE().getSymbol().getText().contains("*") || ctx.VALUE().getSymbol().getText().contains("?"));
  	 }
 
 	@Override
 	public void exitComparison(SearchParser.ComparisonContext ctx)
 	{
-		final String left = ElasticSearchUtil.jsonPropertyToElasticProperty (ctx.FIELD(0).getSymbol().getText());
+		final String left = ElasticSearchUtil.jsonPropertyToElasticProperty(ctx.FIELD().getSymbol().getText());
 		String right;
 		QueryBuilder comparator = null;
 
-		// the second term of the comparison can be first tokenized as FIELD (string without quote) since FIELD is before VALUE (string with optional wildcard, no quote) in the ANTLR4 grammar.
-		if (ctx.FIELD(1) != null) right = ctx.FIELD(1).getSymbol().getText();
-		else if (ctx.NUMBER() != null) right = ctx.NUMBER().getSymbol().getText();
+		if (ctx.NUMBER() != null) right = ctx.NUMBER().getSymbol().getText();
 		else if (ctx.STRINGVAL() != null)
 		{
 			right = ctx.STRINGVAL().getSymbol().getText();
 			right = right.substring(1, right.length()-1);
 		}
-		else if (ctx.VALUE() != null) right = ctx.VALUE().getSymbol().getText();
+		else if (ctx.wildcardFunc() != null) 
+		{
+		    this.wildcard = true;
+		    right = ctx.wildcardFunc().getChild(2).getText();
+		    right = right.substring(1, right.length()-1);
+		}
 		else
 		{
 			log.error("Panic, there are more data types than this version of the lexer knows about.");

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/ElasticSearchUtil.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/ElasticSearchUtil.java
@@ -131,7 +131,7 @@ public class ElasticSearchUtil {
 	}
 	
 	static public ProductWithXmlLabel ESentityProductToAPIProduct(EntitytProductWithBlob ep, URL baseURL) {
-		ElasticSearchUtil.log.info("convert ES object to API object with XML label");
+		log.debug("convert ES object to API object with XML label");
 		ProductWithXmlLabel product = new ProductWithXmlLabel();
 		product.setLabelXml(ep.getPDS4XML());
 		return (ProductWithXmlLabel)addPropertiesFromESEntity(product, ep, baseURL);
@@ -139,7 +139,7 @@ public class ElasticSearchUtil {
 	
 
 	static public Product ESentityProductToAPIProduct(EntityProduct ep, URL baseURL) {
-		ElasticSearchUtil.log.info("convert ES object to API object without XML label");
+		log.debug("convert ES object to API object without XML label");
 		
 		Product product = new Product();
 		

--- a/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductSerializer.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductSerializer.java
@@ -1,12 +1,8 @@
 package gov.nasa.pds.api.engineering.serializer;
 
-import gov.nasa.pds.model.Product;
 import gov.nasa.pds.api.model.xml.ProductWithXmlLabel;
-import gov.nasa.pds.model.Metadata;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Scanner;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
@@ -17,11 +13,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.AbstractHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
-
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 
 
 public class Pds4XmlProductSerializer extends AbstractHttpMessageConverter<ProductWithXmlLabel> {

--- a/src/test/java/gov/nasa/pds/api/engineering/elasticsearch/Antlr4SearchListenerTest.java
+++ b/src/test/java/gov/nasa/pds/api/engineering/elasticsearch/Antlr4SearchListenerTest.java
@@ -53,9 +53,9 @@ public class Antlr4SearchListenerTest
 	}
 
 	@Test
-	public void testEqualWildcard()
+	public void testLikeWildcard()
 	{
-		String qs = "lid eq *pdart14_meap";
+		String qs = "lid like \"*pdart14_meap\"";
 		BoolQueryBuilder query = this.run(qs);
 		
 		Assertions.assertEquals (query.must().size(), 1);
@@ -66,20 +66,22 @@ public class Antlr4SearchListenerTest
 		Assertions.assertEquals (((WildcardQueryBuilder)query.must().get(0)).value(), "*pdart14_meap");
 	}
 
-	@Test
-	public void testNotEqualWildchar()
-	{
-		String qs = "lid ne pdart14_meap?";
-		BoolQueryBuilder query = this.run(qs);
-		
-		Assertions.assertEquals (query.must().size(), 0);
-		Assertions.assertEquals (query.mustNot().size(), 1);
-		Assertions.assertEquals (query.should().size(), 0);
-		Assertions.assertTrue (query.mustNot().get(0) instanceof WildcardQueryBuilder);
-		Assertions.assertEquals (((WildcardQueryBuilder)query.mustNot().get(0)).fieldName(), "lid");
-		Assertions.assertEquals (((WildcardQueryBuilder)query.mustNot().get(0)).value(), "pdart14_meap?");
-	}
+	
+    @Test
+    public void testNotLikeWildchar()
+    {
+        String qs = "lid not like \"pdart14_meap?\"";
+        BoolQueryBuilder query = this.run(qs);
 
+        Assertions.assertEquals(query.must().size(), 0);
+        Assertions.assertEquals(query.mustNot().size(), 1);
+        Assertions.assertEquals(query.should().size(), 0);
+        Assertions.assertTrue(query.mustNot().get(0) instanceof WildcardQueryBuilder);
+        Assertions.assertEquals(((WildcardQueryBuilder) query.mustNot().get(0)).fieldName(), "lid");
+        Assertions.assertEquals(((WildcardQueryBuilder) query.mustNot().get(0)).value(), "pdart14_meap?");
+    }
+
+    
 	@Test
 	public void testEscape()
 	{
@@ -94,20 +96,6 @@ public class Antlr4SearchListenerTest
 		Assertions.assertEquals (((MatchQueryBuilder)query.must().get(0)).value(), "*pdart14_meap?");
 	}
 
-	@Test
-	public void testGroup()
-	{
-		String qs = "( lid eq *pdart14_meap* )";
-		BoolQueryBuilder query = this.run(qs);
-		
-		Assertions.assertEquals (query.must().size(), 1);
-		Assertions.assertEquals (query.mustNot().size(), 0);
-		Assertions.assertEquals (query.should().size(), 0);
-		Assertions.assertTrue (query.must().get(0) instanceof WildcardQueryBuilder);
-		Assertions.assertEquals (((WildcardQueryBuilder)query.must().get(0)).fieldName(), "lid");
-		Assertions.assertEquals (((WildcardQueryBuilder)query.must().get(0)).value(), "*pdart14_meap*");
-
-	}
 
 	@Test
 	public void testGroupedStatementAndExclusiveInequality()
@@ -227,19 +215,6 @@ public class Antlr4SearchListenerTest
 		Assertions.assertFalse (((RangeQueryBuilder)nest.must().get(1)).includeUpper());
 	}
 
-	@Test
-	public void testNoWildcard()
-	{
-		String qs = "ref_lid_target eq urn:nasa:pds:context:target:planet.mercury";
-		BoolQueryBuilder query = this.run(qs);
-
-		Assertions.assertEquals (query.must().size(), 1);
-		Assertions.assertEquals (query.mustNot().size(), 0);
-		Assertions.assertEquals (query.should().size(), 0);
-		Assertions.assertTrue (query.must().get(0) instanceof MatchQueryBuilder);
-		Assertions.assertEquals (((MatchQueryBuilder)query.must().get(0)).fieldName(), "ref_lid_target");
-		Assertions.assertEquals (((MatchQueryBuilder)query.must().get(0)).value(), "urn:nasa:pds:context:target:planet.mercury");
-	}
 	
 	@Test
 	public void testNoWildcardQuoted()


### PR DESCRIPTION
## 🗒️ Summary
- Partially fixed broken logical operators (`and`, `or`) in query lexer / parser. 
- There is still a requirement that an expression with a logical operator has to be surrounded with `()`. For example, `(fieldA eq "abc" and fieldB eq "123)"`. To properly implement this, significant changes are required.
- Introduced `wildcard()` function to handle wildcard queries. For example, `fieldA eq wildcard("*bennu")`. I had to remove support for unquoted values / literals, including unquoted wildcards, because that breaks logical operators and parenthesis.

## Supported values
- String literals, including dates, have to be quoted: `fieldA eq "abc"`, `fieldB le "2016-05-07"`
- Numbers can be unquoted: `fieldA eq 123`
- Wildcards - use `like` or `not like` operator with quoted value: `fieldA like "*bennu"`

## ♻️ Related Issues
https://github.com/NASA-PDS/pds-api/issues/72

## 🏗️ Build Instructions
- Build and install (`mvn install`) `api-search-query-lexer` project first. (See https://github.com/NASA-PDS/api-search-query-lexer/pull/7)
- Then build this project.

