### PR TITLE
Fix README's path to Dockerfile and fix Dockerfiles' file references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,23 @@ Note, the registry index in elasticSearch is hard-coded. It need to be `registry
     mvn clean
     mvn install
     mvn spring-boot:run
-    
+
+👉 **Note:** in order to run in this way, you will need to modify the `spring-boot-starter-thymeleaf` dependency by pinning it to version `1.5.1.RELEASE` and excluding the `logback-classic` artifact in the `pom.xml` file as follows:
+
+```xml
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    <version>1.5.1.RELEASE</version>
+    <exclusions>
+        <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </exclusion>
+    </exclusions>
+</dependency>
+```
+
     
 ### Usage
 
@@ -83,7 +99,7 @@ Have a registry deployed, for example with docker as described in https://github
 
 ```
 docker image build --build-arg version=$(git rev-parse HEAD) \
-             --file Dockerfile.local \
+             --file docker/Dockerfile.local \
              --tag registry-api-service:$(git rev-parse HEAD) \
              .
 ```

--- a/docker/Dockerfile.http
+++ b/docker/Dockerfile.http
@@ -15,9 +15,9 @@ RUN mkdir /usr/local/registry-api-service \
  && echo ${VERSION} > version.txt
 
 # Copy the data into the building container
-COPY LICENSE.txt /usr/local/registry-api-service
+COPY LICENSE.md /usr/local/registry-api-service
 COPY NOTICE.txt /usr/local/registry-api-service
-COPY README.txt /usr/local/registry-api-service
+COPY README.md /usr/local/registry-api-service
 
 # Resources shared with the rest of the world
 EXPOSE 80

--- a/docker/Dockerfile.http.dev
+++ b/docker/Dockerfile.http.dev
@@ -22,9 +22,9 @@ RUN mkdir /usr/local/registry-api-service \
  && rm -rf /var/lib/apt/lists/*
 
 # Copy the data into the building container
-COPY LICENSE.txt /usr/local/registry-api-service
+COPY LICENSE.md /usr/local/registry-api-service
 COPY NOTICE.txt /usr/local/registry-api-service
-COPY README.txt /usr/local/registry-api-service
+COPY README.md /usr/local/registry-api-service
 
 # Resources shared with the rest of the world
 EXPOSE 80

--- a/docker/Dockerfile.https
+++ b/docker/Dockerfile.https
@@ -18,9 +18,9 @@ RUN mkdir /usr/local/registry-api-service \
  && echo ${VERSION} > version.txt
 
 # Copy the data into the building container
-COPY LICENSE.txt /usr/local/registry-api-service
+COPY LICENSE.md /usr/local/registry-api-service
 COPY NOTICE.txt /usr/local/registry-api-service
-COPY README.txt /usr/local/registry-api-service
+COPY README.md /usr/local/registry-api-service
 
 # Resources shared with the rest of the world
 EXPOSE 443

--- a/docker/Dockerfile.https.dev
+++ b/docker/Dockerfile.https.dev
@@ -18,9 +18,9 @@ RUN mkdir /usr/local/registry-api-service \
  && echo ${VERSION} > version.txt
 
 # Copy the data into the building container
-COPY LICENSE.txt /usr/local/registry-api-service
+COPY LICENSE.md /usr/local/registry-api-service
 COPY NOTICE.txt /usr/local/registry-api-service
-COPY README.txt /usr/local/registry-api-service
+COPY README.md /usr/local/registry-api-service
 
 # Resources shared with the rest of the world
 EXPOSE 443

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -17,9 +17,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 RUN mkdir /usr/local/registry-api-service-${VERSION}
 
 # Copy the data into the building container
-COPY LICENSE.txt /usr/local/registry-api-service-${VERSION}
+COPY LICENSE.md /usr/local/registry-api-service-${VERSION}
 COPY NOTICE.txt /usr/local/registry-api-service-${VERSION}
-COPY README.txt /usr/local/registry-api-service-${VERSION}
+COPY README.md /usr/local/registry-api-service-${VERSION}
 COPY pom.xml /usr/local/registry-api-service-${VERSION}
 COPY src /usr/local/registry-api-service-${VERSION}/src
 


### PR DESCRIPTION
## 🗒️ Summary

Merge this to fix Docker image creation (file extension changes) as well as a minor documentation bug in the `README.md`.

## ⚙️ Test Data and/or Report

```console
$ mvn test
[INFO] Scanning for projects...
…
[INFO] BUILD SUCCESS
…
$ echo \U+1F46F\015♂️
👯‍♂️
```

## ♻️ Related Issues

- NASA-PDS/devops#10

