### PR TITLE
(1) Replace 'lidvid' with 'identifier', (2) 'latest' and 'all' APIs

### DIFF
--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
@@ -82,17 +82,41 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     }    
     
     
-    public ResponseEntity<Products> collectionsOfABundle(@ApiParam(value = "lidvid (urn)",required=true) @PathVariable("lidvid") String lidvid
-            ,@ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue="0") Integer start
-            ,@ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue="100") Integer limit
-            ,@ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields
-            ,@ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort
-            ,@ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue="false") Boolean onlySummary
-            )
+    public ResponseEntity<Products> collectionsOfABundle(
+            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid,
+            @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
+            @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
+            @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
+            @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
+            @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
     {
-            return this.getBundlesCollectionsEntity(lidvid, start, limit, fields, sort, onlySummary);
+        return this.getBundlesCollectionsEntity(lidvid, start, limit, fields, sort, onlySummary);
     }
-
+    
+    
+    public ResponseEntity<Products> collectionsOfABundleAll(
+            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid,
+            @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
+            @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
+            @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
+            @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
+            @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
+    {
+        return new ResponseEntity<Products>(HttpStatus.NOT_IMPLEMENTED);
+    }    
+    
+    
+    public ResponseEntity<Products> collectionsOfABundleLatest(
+            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid,
+            @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
+            @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
+            @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
+            @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
+            @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
+    {
+        return new ResponseEntity<Products>(HttpStatus.NOT_IMPLEMENTED);
+    }
+    
     
     private Products getBundleCollections(String lidvid, int start, int limit, List<String> fields, 
             List<String> sort, boolean onlySummary) throws IOException, LidVidNotFoundException
@@ -102,7 +126,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
         lidvid = productBO.getLidVidDao().getLatestLidVidFromLid(lidvid);
         MyBundlesApiController.log.info("Get bundle's collections. Bundle LIDVID = " + lidvid);
         
-        List<String> clidvids = productBO.getBundleDao().getBundleCollectionLidVids(lidvid);
+        List<String> clidvids = productBO.getBundleDao().getBundleCollectionLidVids(lidvid, false);
 
         HashSet<String> uniqueProperties = new HashSet<String>();
         Products products = new Products();
@@ -207,7 +231,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
 
         int iteration=0,wsize=0;
         HashSet<String> uniqueProperties = new HashSet<String>();
-        List<String> clidvids = productBO.getBundleDao().getBundleCollectionLidVids(lidvid);
+        List<String> clidvids = productBO.getBundleDao().getBundleCollectionLidVids(lidvid, false);
         List<String> plidvids = new ArrayList<String>();   
         List<String> wlidvids = new ArrayList<String>();
         Products products = new Products();

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
@@ -5,6 +5,7 @@ import gov.nasa.pds.api.base.BundlesApi;
 import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchHitIterator;
 import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchRegistrySearchRequestBuilder;
 import gov.nasa.pds.api.engineering.elasticsearch.business.LidVidNotFoundException;
+import gov.nasa.pds.api.engineering.elasticsearch.business.ProductVersionSelector;
 import gov.nasa.pds.model.Products;
 import gov.nasa.pds.model.Summary;
 
@@ -90,7 +91,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
             @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
             @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
     {
-        return this.getBundlesCollectionsEntity(lidvid, start, limit, fields, sort, onlySummary);
+        return getBundlesCollectionsEntity(lidvid, start, limit, fields, sort, onlySummary, ProductVersionSelector.ORIGINAL);
     }
     
     
@@ -102,7 +103,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
             @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
             @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
     {
-        return new ResponseEntity<Products>(HttpStatus.NOT_IMPLEMENTED);
+        return getBundlesCollectionsEntity(lidvid, start, limit, fields, sort, onlySummary, ProductVersionSelector.ALL);
     }    
     
     
@@ -114,16 +115,17 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
             @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
             @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
     {
-        return new ResponseEntity<Products>(HttpStatus.NOT_IMPLEMENTED);
+        return getBundlesCollectionsEntity(lidvid, start, limit, fields, sort, onlySummary, ProductVersionSelector.LATEST);
     }
     
     
     private Products getBundleCollections(String lidvid, int start, int limit, List<String> fields, 
-            List<String> sort, boolean onlySummary) throws IOException, LidVidNotFoundException
+            List<String> sort, boolean onlySummary, ProductVersionSelector versionSelector) 
+                    throws IOException, LidVidNotFoundException
     {
         long begin = System.currentTimeMillis();
         
-        lidvid = productBO.getLidVidDao().getLatestLidVidFromLid(lidvid);
+        lidvid = productBO.getLidVidDao().getLatestLidVidByLid(lidvid);
         MyBundlesApiController.log.info("Get bundle's collections. Bundle LIDVID = " + lidvid);
         
         List<String> clidvids = productBO.getBundleDao().getBundleCollectionLidVids(lidvid, false);
@@ -160,7 +162,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
 
     
     private ResponseEntity<Products> getBundlesCollectionsEntity(String lidvid, int start, int limit, 
-            List<String> fields, List<String> sort, boolean onlySummary)
+            List<String> fields, List<String> sort, boolean onlySummary, ProductVersionSelector versionSelector)
     {
          String accept = this.request.getHeader("Accept");
          MyBundlesApiController.log.info("accept value is " + accept);
@@ -173,7 +175,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
          {
              try
              {
-                 Products products = getBundleCollections(lidvid, start, limit, fields, sort, onlySummary);
+                 Products products = getBundleCollections(lidvid, start, limit, fields, sort, onlySummary, versionSelector);
                  return new ResponseEntity<Products>(products, HttpStatus.OK);
              }
              catch (IOException e)

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
@@ -25,9 +25,10 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 
 @javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2021-02-16T16:35:42.434-08:00[America/Los_Angeles]")
@@ -46,7 +47,8 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     }
 
     @Override
-    public ResponseEntity<Object> bundleByLidvid(@ApiParam(value = "lidvid (urn)",required=true) @PathVariable("lidvid") String lidvid)
+    public ResponseEntity<Object> bundleByLidvid(
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid)
     {
         return this.getLatestProductResponseEntity(lidvid);
     }
@@ -54,7 +56,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     
     @Override
     public ResponseEntity<Object> bundleByLidvidLatest(
-            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid)
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid)
     {
         return this.getLatestProductResponseEntity(lidvid);
     }
@@ -62,7 +64,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     
     @Override    
     public ResponseEntity<Object> bundleByLidvidAll(
-            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid,
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid,
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "10") @Valid @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit)
     {
@@ -84,7 +86,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     
     
     public ResponseEntity<Products> collectionsOfABundle(
-            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid,
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid,
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
             @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
@@ -96,7 +98,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     
     
     public ResponseEntity<Products> collectionsOfABundleAll(
-            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid,
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid,
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
             @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
@@ -108,7 +110,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
     
     
     public ResponseEntity<Products> collectionsOfABundleLatest(
-            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid,
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid,
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
             @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
@@ -138,7 +140,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
             clidvids = productBO.getBundleDao().getBundleCollectionLidVids(lidvid);
         }
 
-        HashSet<String> uniqueProperties = new HashSet<String>();
+        Set<String> uniqueProperties = new TreeSet<String>();
         Products products = new Products();
         Summary summary = new Summary();
 
@@ -160,7 +162,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
         }
         else 
         {
-            MyBundlesApiController.log.warn ("Did not find any collections for bundle lidvid: " + lidvid);
+            log.warn("Did not find any collections for bundle lidvid: " + lidvid);
         }
 
         summary.setProperties(new ArrayList<String>(uniqueProperties));
@@ -241,7 +243,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
         MyBundlesApiController.log.info("request bundle lidvid, children of products: " + lidvid);
 
         int iteration=0,wsize=0;
-        HashSet<String> uniqueProperties = new HashSet<String>();
+        Set<String> uniqueProperties = new TreeSet<String>();
         List<String> clidvids = productBO.getBundleDao().getBundleCollectionLidVids(lidvid);
         List<String> plidvids = new ArrayList<String>();   
         List<String> wlidvids = new ArrayList<String>();

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
@@ -91,7 +91,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
             @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
             @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
     {
-        return getBundlesCollectionsEntity(lidvid, start, limit, fields, sort, onlySummary, ProductVersionSelector.ORIGINAL);
+        return getBundlesCollectionsEntity(lidvid, start, limit, fields, sort, onlySummary, ProductVersionSelector.LATEST);
     }
     
     
@@ -128,7 +128,15 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
         lidvid = productBO.getLidVidDao().getLatestLidVidByLid(lidvid);
         MyBundlesApiController.log.info("Get bundle's collections. Bundle LIDVID = " + lidvid);
         
-        List<String> clidvids = productBO.getBundleDao().getBundleCollectionLidVids(lidvid, false);
+        List<String> clidvids = null;
+        if(versionSelector == ProductVersionSelector.ALL)
+        {
+            clidvids = productBO.getBundleDao().getAllBundleCollectionLidVids(lidvid);
+        }
+        else
+        {
+            clidvids = productBO.getBundleDao().getBundleCollectionLidVids(lidvid);
+        }
 
         HashSet<String> uniqueProperties = new HashSet<String>();
         Products products = new Products();
@@ -225,6 +233,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
          else return new ResponseEntity<Products>(HttpStatus.NOT_IMPLEMENTED);
     }
 
+    
     private Products getProductChildren(String lidvid, int start, int limit, List<String> fields, List<String> sort, boolean onlySummary) throws IOException,LidVidNotFoundException
     {
     long begin = System.currentTimeMillis();
@@ -233,7 +242,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
 
         int iteration=0,wsize=0;
         HashSet<String> uniqueProperties = new HashSet<String>();
-        List<String> clidvids = productBO.getBundleDao().getBundleCollectionLidVids(lidvid, false);
+        List<String> clidvids = productBO.getBundleDao().getBundleCollectionLidVids(lidvid);
         List<String> plidvids = new ArrayList<String>();   
         List<String> wlidvids = new ArrayList<String>();
         Products products = new Products();

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
@@ -48,21 +48,22 @@ public class MyCollectionsApiController extends MyProductsApiBareController impl
     }
     
     
-    public ResponseEntity<Object> collectionsByLidvid(@ApiParam(value = "lidvid (urn)",required=true) @PathVariable("lidvid") String lidvid) {
+    public ResponseEntity<Object> collectionsByLidvid(
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid)
+    {
         return this.getLatestProductResponseEntity(lidvid);
     }
 
-
     @Override
     public ResponseEntity<Object> collectionsByLidvidLatest(
-            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid)
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid)
     {
         return this.getLatestProductResponseEntity(lidvid);
     }
     
     
     public ResponseEntity<Object> collectionsByLidvidAll(
-            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid,
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid,
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "10") @Valid @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit)
     {

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
@@ -83,52 +83,84 @@ public class MyCollectionsApiController extends MyProductsApiBareController impl
     }    
 
     
-    public ResponseEntity<Products> productsOfACollection(@ApiParam(value = "lidvid (urn)",required=true) @PathVariable("lidvid") String lidvid
-            ,@ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue="0") Integer start
-            ,@ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue="100") Integer limit
-            ,@ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields
-            ,@ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort
-            ,@ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue="false") Boolean onlySummary
-            ) {
-        
-         MyCollectionsApiController.log.info("Get productsOfACollection");
-        
-         String accept = this.request.getHeader("Accept");
-         MyCollectionsApiController.log.info("accept value is " + accept);
-         if ((accept != null 
-                && (accept.contains("application/json") 
-                        || accept.contains("text/html")
-                        || accept.contains("application/xml")
-                        || accept.contains("application/pds4+xml")
-                        || accept.contains("*/*")))
-            || (accept == null)) {
-            
-            try {
-                
-            
-                Products products = this.getProductChildren(lidvid, start, limit, fields, sort, onlySummary);
-                
-                /* REMOVED since it breaks the result when only-smmary argument is set to true
-                if (products.getData() == null || products.getData().size() == 0)
-                    return new ResponseEntity<Products>(products, HttpStatus.NOT_FOUND);
-                else
-                */
-                
-                return new ResponseEntity<Products>(products, HttpStatus.OK);
-          } catch (LidVidNotFoundException e) {
-              log.error("Couldn't find the lidvid " + e.getMessage());
-              return new ResponseEntity<Products>(HttpStatus.NOT_FOUND);
-              
-          } catch (IOException e) {
-               log.error("Couldn't serialize response for content type " + accept, e);
-               return new ResponseEntity<Products>(HttpStatus.INTERNAL_SERVER_ERROR);
-          }
-             
-         }
-         else return new ResponseEntity<Products>(HttpStatus.NOT_IMPLEMENTED);
+    public ResponseEntity<Products> productsOfACollection(
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String identifier,
+            @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
+            @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
+            @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
+            @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
+            @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
+    {
+        return getProductsOfACollectionResponseEntity(identifier, start, limit, fields, sort, onlySummary);
     }
-            
-        
+
+    
+    public ResponseEntity<Products> productsOfACollectionLatest(
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String identifier,
+            @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
+            @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
+            @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
+            @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
+            @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
+    {
+        return getProductsOfACollectionResponseEntity(identifier, start, limit, fields, sort, onlySummary);
+    }
+
+    
+    public ResponseEntity<Products> productsOfACollectionAll(
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String identifier,
+            @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
+            @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "100") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Integer limit,
+            @ApiParam(value = "returned fields, syntax field0,field1") @Valid @RequestParam(value = "fields", required = false) List<String> fields,
+            @ApiParam(value = "sort results, syntax asc(field0),desc(field1)") @Valid @RequestParam(value = "sort", required = false) List<String> sort,
+            @ApiParam(value = "only return the summary, useful to get the list of available properties", defaultValue = "false") @Valid @RequestParam(value = "only-summary", required = false, defaultValue = "false") Boolean onlySummary)
+    {
+        return getProductsOfACollectionResponseEntity(identifier, start, limit, fields, sort, onlySummary);
+    }    
+    
+    
+    ResponseEntity<Products> getProductsOfACollectionResponseEntity(String lidvid, int start, int limit, 
+            List<String> fields, List<String> sort, boolean onlySummary)
+    {
+        MyCollectionsApiController.log.info("Get productsOfACollection");
+
+        String accept = this.request.getHeader("Accept");
+        MyCollectionsApiController.log.info("accept value is " + accept);
+        if ((accept != null && (accept.contains("application/json") || accept.contains("text/html")
+                || accept.contains("application/xml") || accept.contains("application/pds4+xml")
+                || accept.contains("*/*"))) || (accept == null))
+        {
+            try
+            {
+                Products products = this.getProductChildren(lidvid, start, limit, fields, sort, onlySummary);
+
+                /*
+                 * REMOVED since it breaks the result when only-smmary argument is set to true
+                 * if (products.getData() == null || products.getData().size() == 0) return new
+                 * ResponseEntity<Products>(products, HttpStatus.NOT_FOUND); else
+                 */
+
+                return new ResponseEntity<Products>(products, HttpStatus.OK);
+            }
+            catch (LidVidNotFoundException e)
+            {
+                log.error("Couldn't find the lidvid " + e.getMessage());
+                return new ResponseEntity<Products>(HttpStatus.NOT_FOUND);
+
+            }
+            catch (IOException e)
+            {
+                log.error("Couldn't serialize response for content type " + accept, e);
+                return new ResponseEntity<Products>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+        }
+        else
+        {
+            return new ResponseEntity<Products>(HttpStatus.NOT_IMPLEMENTED);
+        }
+    }
+    
+    
     private Products getProductChildren(String lidvid, int start, int limit, List<String> fields, List<String> sort, boolean onlySummary) throws IOException, LidVidNotFoundException
     {
           long begin = System.currentTimeMillis();

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiBareController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiBareController.java
@@ -6,7 +6,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,6 +34,7 @@ import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchRegistrySearchReq
 import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchUtil;
 import gov.nasa.pds.api.engineering.elasticsearch.GetProductsRequest;
 import gov.nasa.pds.api.engineering.elasticsearch.business.LidVidNotFoundException;
+import gov.nasa.pds.api.engineering.elasticsearch.business.LidVidUtils;
 import gov.nasa.pds.api.engineering.elasticsearch.business.ProductBusinessObject;
 import gov.nasa.pds.api.engineering.elasticsearch.entities.EntityProduct;
 
@@ -78,7 +78,7 @@ public class MyProductsApiBareController {
     }
 
     @SuppressWarnings("unchecked")
-    protected void fillProductsFromLidvids (Products products, HashSet<String> uniqueProperties, List<String> lidvids, List<String> fields, boolean onlySummary) throws IOException
+    protected void fillProductsFromLidvids (Products products, Set<String> uniqueProperties, List<String> lidvids, List<String> fields, boolean onlySummary) throws IOException
     {
         for (final Map<String,Object> kvp : new ElasticSearchHitIterator(lidvids.size(), this.esRegistryConnection.getRestHighLevelClient(),
                 ElasticSearchRegistrySearchRequestBuilder.getQueryFieldsFromKVP("lidvid",
@@ -97,7 +97,7 @@ public class MyProductsApiBareController {
 
     
     @SuppressWarnings("unchecked")
-    protected void fillProductsFromParents (Products products, HashSet<String> uniqueProperties, List<Map<String,Object>> results, boolean onlySummary) throws IOException
+    protected void fillProductsFromParents (Products products, Set<String> uniqueProperties, List<Map<String,Object>> results, boolean onlySummary) throws IOException
     {
         for (Map<String,Object> kvp : results)
         {
@@ -123,7 +123,7 @@ public class MyProductsApiBareController {
         
         Products products = new Products();
         
-        HashSet<String> uniqueProperties = new HashSet<String>();
+        Set<String> uniqueProperties = new TreeSet<String>();
         
         Summary summary = new Summary();
 
@@ -165,22 +165,15 @@ public class MyProductsApiBareController {
 
                     products.addDataItem(product);
                 }
-                
             }
-     
-            
         }
-        
         
         summary.setProperties(new ArrayList<String>(uniqueProperties));
         summary.setTook((int)(System.currentTimeMillis() - begin));
         return products;
     }
-    
  
 
-    
-    
     protected ResponseEntity<Object> getProductsResponseEntity(String q, String keyword, int start, int limit,
             List<String> fields, List<String> sort, boolean onlySummary)
     {
@@ -233,7 +226,7 @@ public class MyProductsApiBareController {
     }    
     
     
-    protected ResponseEntity<Object> getAllProductsResponseEntity(String lidvid, int start, int limit)
+    protected ResponseEntity<Object> getAllProductsResponseEntity(String identifier, int start, int limit)
     {
         String accept = this.request.getHeader("Accept");
         log.debug("accept value is " + accept);
@@ -242,7 +235,17 @@ public class MyProductsApiBareController {
         {
             try
             {
-                Products products = getProductsByLid(lidvid, start, limit);
+                long startTs = System.currentTimeMillis();
+                
+                String lid = LidVidUtils.extractLidFromLidVid(identifier);
+                Products products = getProductsByLid(lid, start, limit);
+                
+                long endTs = System.currentTimeMillis();
+                if(products != null)
+                {
+                    products.getSummary().setTook((int)(endTs - startTs));
+                }
+                
                 return new ResponseEntity<Object>(products, HttpStatus.OK);
             }
             catch (IOException e)
@@ -295,7 +298,9 @@ public class MyProductsApiBareController {
 
             products.addDataItem(product);
         }
+
         
+        summary.setHits((int)resp.getHits().getTotalHits().value);
         summary.setProperties(new ArrayList<String>(uniqueProperties));
         return products;
     }
@@ -314,7 +319,7 @@ public class MyProductsApiBareController {
             
             try 
             {
-                lidvid = this.productBO.getLatestLidVidFromLid(lidvid);
+                lidvid = this.productBO.getLidVidDao().getLatestLidVidByLid(lidvid);
                 
                 Object product = null;
                 

--- a/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
@@ -59,7 +59,7 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
     
      
     public ResponseEntity<Object> productsByLidvid(
-            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid)
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid)
     {
         return this.getLatestProductResponseEntity(lidvid);
     }
@@ -67,7 +67,7 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
     
     @Override
     public ResponseEntity<Object> productsByLidvidLatest(
-            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid)
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid)
     {
         return this.getLatestProductResponseEntity(lidvid);
     }    
@@ -75,7 +75,7 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
     
     @Override
     public ResponseEntity<Object> productsByLidvidAll(
-            @ApiParam(value = "lidvid (urn)", required = true) @PathVariable("lidvid") String lidvid,
+            @ApiParam(value = "lidvid or lid", required = true) @PathVariable("identifier") String lidvid,
             @ApiParam(value = "offset in matching result list, for pagination", defaultValue = "0") @Valid @RequestParam(value = "start", required = false, defaultValue = "0") Integer start,
             @ApiParam(value = "maximum number of matching results returned, for pagination", defaultValue = "10") @Valid @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit)
     {

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/BundleDAO.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/BundleDAO.java
@@ -129,6 +129,13 @@ public class BundleDAO
     }
 
     
+    /**
+     * Get all versions of bundle's collections by bundle LIDVID.
+     * @param bundleLidVid bundle LIDVID (Could not pass LID here)
+     * @return a list of collection LIDVIDs
+     * @throws IOException IO exception 
+     * @throws LidVidNotFoundException LIDVID not found exception
+     */
     public List<String> getAllBundleCollectionLidVids(String bundleLidVid) 
             throws IOException, LidVidNotFoundException
     {
@@ -161,7 +168,7 @@ public class BundleDAO
         if(!ids.isEmpty())
         {
             // Get the latest versions of LIDs (Return LIDVIDs)
-            ids = LidVidUtils.getLatestLidVidsByLids(esConnection, ids);
+            ids = LidVidUtils.getAllLidVidsByLids(esConnection, ids);
             return ids;
         }
         

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/BundleDAO.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/BundleDAO.java
@@ -44,7 +44,22 @@ public class BundleDAO
     }
 
 
-    public List<String> getBundleCollectionLidVids(String bundleLidVid, boolean latest) throws IOException, LidVidNotFoundException
+    /**
+     * Get collections of a bundle by bundle LIDVID. 
+     * <p>If latest flag is true, then only latest versions of collections are returned 
+     * even if LIDVID reference in a bundle points to previous version of a collection.
+     * <p> If latest flag is false, then if a bundle has LIDVID collection references, 
+     * then those collections are returned. If a bundle has LID collection references,
+     * then the latest versions of collections are returned.
+     * @param bundleLidVid bundle LIDVID (Could not pass LID here)
+     * @param latest if true, return latest collection versions, even if LIDVID collection
+     * references point to previous versions.
+     * @return a list of collection LIDVIDs
+     * @throws IOException IO exception
+     * @throws LidVidNotFoundException LIDVID not found exception
+     */
+    public List<String> getBundleCollectionLidVids(String bundleLidVid, boolean latest) 
+            throws IOException, LidVidNotFoundException
     {
         // Get bundle by lidvid.
         GetRequest esRequest = new GetRequest(esConnection.getRegistryIndex(), bundleLidVid);
@@ -89,7 +104,47 @@ public class BundleDAO
         if(!ids.isEmpty())
         {
             // Get the latest versions of LIDs (Return LIDVIDs)
-            ids = LidVidUtils.getLatestLids(esConnection, ids);
+            ids = LidVidUtils.getLatestLidVidsByLids(esConnection, ids);
+            return ids;
+        }
+        
+        return new ArrayList<String>(0);
+    }
+
+    
+    public List<String> getAllBundleCollectionLidVids(String bundleLidVid, boolean latest) 
+            throws IOException, LidVidNotFoundException
+    {
+        // Get bundle by lidvid.
+        GetRequest esRequest = new GetRequest(esConnection.getRegistryIndex(), bundleLidVid);
+        
+        // Fetch collection references only.
+        String[] includes = { 
+                "ref_lid_collection", "ref_lid_collection_secondary"
+        };
+        FetchSourceContext fetchSourceContext = new FetchSourceContext(true, includes, null);
+        esRequest.fetchSourceContext(fetchSourceContext);
+        
+        // Call Elasticsearch
+        RestHighLevelClient client = esConnection.getRestHighLevelClient();
+        GetResponse esResponse = client.get(esRequest, RequestOptions.DEFAULT);
+        if(!esResponse.isExists()) throw new LidVidNotFoundException(bundleLidVid);
+
+        // Get fields
+        Map<String, Object> fieldMap = esResponse.getSourceAsMap();
+
+        // Lid references (e.g., Kaguya bundle)
+        List<String> primaryIds = ESResponseUtils.getFieldValues(fieldMap, "ref_lid_collection");
+        List<String> secondaryIds = ESResponseUtils.getFieldValues(fieldMap, "ref_lid_collection_secondary");
+
+        List<String> ids = new ArrayList<String>();
+        if(primaryIds != null) ids.addAll(primaryIds); 
+        if(secondaryIds != null) ids.addAll(secondaryIds);
+        
+        if(!ids.isEmpty())
+        {
+            // Get the latest versions of LIDs (Return LIDVIDs)
+            ids = LidVidUtils.getLatestLidVidsByLids(esConnection, ids);
             return ids;
         }
         

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/LidVidDAO.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/LidVidDAO.java
@@ -25,21 +25,21 @@ public class LidVidDAO
      * @throws IOException
      * @throws LidVidNotFoundException
      */
-    public String getLatestLidVidFromLid(String lid) throws IOException, LidVidNotFoundException
+    public String getLatestLidVidByLid(String lid) throws IOException, LidVidNotFoundException
     {
         if(lid == null) throw new LidVidNotFoundException("");
         if(lid.contains("::")) return lid;
         
-        List<String> lidvids = LidVidUtils.getLatestLids(esConnection, Arrays.asList(lid));
+        List<String> lidvids = LidVidUtils.getLatestLidVidsByLids(esConnection, Arrays.asList(lid));
         if(lidvids == null || lidvids.isEmpty()) throw new LidVidNotFoundException(lid);
         
         return lidvids.get(0);
     }
 
 
-    public List<String> getLatestLidVidsFromLids(Collection<String> lids) throws IOException
+    public List<String> getLatestLidVidsByLids(Collection<String> lids) throws IOException
     {
-        return LidVidUtils.getLatestLids(esConnection, lids);
+        return LidVidUtils.getLatestLidVidsByLids(esConnection, lids);
     }
 
 }

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/LidVidUtils.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/LidVidUtils.java
@@ -39,7 +39,7 @@ public class LidVidUtils
      * @return list of LIDVIDs
      * @throws IOException
      */
-    public static List<String> getLatestLids(ElasticSearchRegistryConnection esConnection, Collection<String> lids) throws IOException
+    public static List<String> getLatestLidVidsByLids(ElasticSearchRegistryConnection esConnection, Collection<String> lids) throws IOException
     {
         // Create request
         SearchSourceBuilder src = buildGetLatestLidVidsRequest(lids);

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/ProductVersionSelector.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/ProductVersionSelector.java
@@ -1,0 +1,25 @@
+package gov.nasa.pds.api.engineering.elasticsearch.business;
+
+/**
+ * Used by API calls, such as "/bundles/{lidvid}/collections", 
+ * "/bundles/{lidvid}/collections/latest", 
+ * "/bundles/{lidvid}/collections/all", etc., 
+ * to select product versions.
+ * 
+ * @author karpenko
+ */
+public enum ProductVersionSelector
+{
+    /**
+     * Original version of a product, e.g., from LIDVID reference field
+     */
+    ORIGINAL,
+    /**
+     * All versions of a product
+     */
+    ALL, 
+    /**
+     * Latest version of a product
+     */
+    LATEST
+}

--- a/src/test/java/tt/TestLidVidUtils.java
+++ b/src/test/java/tt/TestLidVidUtils.java
@@ -24,10 +24,14 @@ public class TestLidVidUtils
 
         
         BundleDAO dao = new BundleDAO(con);
-        List<String> ids = dao.getBundleCollectionLidVids("urn:nasa:pds:orex.spice::3.0");
+        //List<String> ids = dao.getBundleCollectionLidVids("urn:nasa:pds:orex.spice::3.0");
+        List<String> ids = dao.getAllBundleCollectionLidVids("urn:nasa:pds:orex.spice::3.0");
         
         System.out.println();
-        System.out.println(ids);
+        for(String id: ids)
+        {
+            System.out.println(id);
+        }
         System.out.println();
         
         con.close();

--- a/src/test/java/tt/TestLidVidUtils.java
+++ b/src/test/java/tt/TestLidVidUtils.java
@@ -1,12 +1,11 @@
 package tt;
 
-import java.util.Arrays;
 import java.util.List;
 
 
 import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchRegistryConnection;
 import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchRegistryConnectionImpl;
-import gov.nasa.pds.api.engineering.elasticsearch.business.LidVidUtils;
+import gov.nasa.pds.api.engineering.elasticsearch.business.BundleDAO;
 
 
 public class TestLidVidUtils
@@ -20,8 +19,16 @@ public class TestLidVidUtils
         
         ElasticSearchRegistryConnection con = new ElasticSearchRegistryConnectionImpl();
         
-        List<String> ids = LidVidUtils.getLatestLids(con, Arrays.asList("urn:nasa:pds:orex.spice"));
+        //List<String> ids = LidVidUtils.getLatestLids(con, Arrays.asList("urn:nasa:pds:orex.spice"));
+        //System.out.println(ids);
+
+        
+        BundleDAO dao = new BundleDAO(con);
+        List<String> ids = dao.getBundleCollectionLidVids("urn:nasa:pds:orex.spice::3.0", false);
+        
+        System.out.println();
         System.out.println(ids);
+        System.out.println();
         
         con.close();
     }

--- a/src/test/java/tt/TestLidVidUtils.java
+++ b/src/test/java/tt/TestLidVidUtils.java
@@ -24,7 +24,7 @@ public class TestLidVidUtils
 
         
         BundleDAO dao = new BundleDAO(con);
-        List<String> ids = dao.getBundleCollectionLidVids("urn:nasa:pds:orex.spice::3.0", false);
+        List<String> ids = dao.getBundleCollectionLidVids("urn:nasa:pds:orex.spice::3.0");
         
         System.out.println();
         System.out.println(ids);


### PR DESCRIPTION
## 🗒️ Summary
(1) Replace 'lidvid' with 'identifier'
(2) 'latest' and 'all' APIs - implemented
-  `collections_of_a_bundle_all (bundle/{lidvid}/collections/all)`
- `collections_of_a_bundle_latest (bundle/{lidvid}/collections/latest)`
- `products_of_a_collection_all (collection/{lidvid}/products/all)` 

(3) 'latest' and 'all' APIs - added the API, but it returns the same results as `collection/{lidvid}/products/all`
- `products_of_a_collection_latest (collection/{lidvid}/products/latest)`



See https://github.com/NASA-PDS/pds-api/issues/108 and https://github.com/NASA-PDS/pds-api/issues/115

## ⚙️ Test Data and/or Report
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


