### PR TITLE
Add LB listener rule to terraform script

### DIFF
--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -7,7 +7,7 @@
 #    aws secretsmanager delete-secret --secret-id <id> --force-delete-without-recovery --region <region>
 #
 resource aws_secretsmanager_secret "es_login_secret" {
-  name = "pds/${var.node_name_abbr}/registry/es/login"
+  name = "pds/${var.node_name_abbr}/${var.venue}/registry/es/login"
 
   tags = {
     Alpha = var.node_name_abbr
@@ -28,7 +28,7 @@ EOF
 
 # Store the list of es hosts as a parameter to be injected into the container as an environment variable
 resource "aws_ssm_parameter" "es_hosts_parameter" {
-  name = "/pds/${var.node_name_abbr}/registry/es/hosts"
+  name = "/pds/${var.node_name_abbr}/${var.venue}/registry/es/hosts"
   type = "String"
   value = var.es_hosts
 
@@ -41,7 +41,7 @@ resource "aws_ssm_parameter" "es_hosts_parameter" {
 
 # Store the node name as a parameter to be injected into the container as an environment variable
 resource "aws_ssm_parameter" "node_name_parameter" {
-  name = "/pds/${var.node_name_abbr}/registry/node_name"
+  name = "/pds/${var.node_name_abbr}/${var.venue}/registry/node_name"
   type = "String"
   value = var.node_name_abbr
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -65,7 +65,23 @@ variable "es_hosts" {
 
 variable "aws_fg_image" {
   description = "AWS image name for Fargate"
-  default = "445837347542.dkr.ecr.us-west-2.amazonaws.com/pds-registry-api-service:0.4.1-SNAPSHOT.http"
+  # default = "445837347542.dkr.ecr.us-west-2.amazonaws.com/pds-registry-api-service:0.5.0-SNAPSHOT.http"
+}
+
+variable "aws_lb_listener_arn" {
+  description = "ARN of the AWS LB listener to associated with the service target group"
+  default = "arn:aws:elasticloadbalancing:us-west-2:445837347542:listener/app/pds-en-ecs/7870b4ad486ca87b/085568f01bd7a139"
+}
+
+variable "http_header_forward_name" {
+  description = "Name of the http header for which requests are forwarded to this service's target group"
+  default = "x-request-node"
+}
+
+variable "http_header_forward_value" {
+  description = "Value of the http_header for which requests are forwarded to this service's target group"
+  # except for production, the venue is part of the x-request-node value
+  # default = ${var.node_name_abbr}-${var.venue}"
 }
 
 variable "aws_fg_cpu_units" {


### PR DESCRIPTION
## 🗒️ Summary
Add creation of LB listener rule to terraform script to associate the listener to the target group and route based on x-request-node value (i.e. node-venue)

This PR also adds venue to secret and parameter names.