### PR TITLE
Revert to ES API v7.13.3 for compatibility w/ AWS ES 7.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ POSSIBILITY OF SUCH DAMAGE.
 	<properties>
 		<jackson-version>2.10.0</jackson-version>
 		<springfox-version>2.7.0</springfox-version>
-		<elasticsearch.version>7.15.1</elasticsearch.version>
+		<elasticsearch.version>7.13.3</elasticsearch.version>
 	</properties>
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/SearchRequestBuilder.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/SearchRequestBuilder.java
@@ -3,7 +3,7 @@ package gov.nasa.pds.api.engineering.elasticsearch;
 import java.util.concurrent.TimeUnit;
 
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;

--- a/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/LidVidUtils.java
+++ b/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/LidVidUtils.java
@@ -10,7 +10,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.Aggregation;


### PR DESCRIPTION
## 🗒️ Summary
Change version in pom.xml from 7.15.1 to 7.13.3 so that the registry service can work against AWS ES 7.10.

The only readily detectable implication of this wrt the registry is that the package of TimeValue has changed, requiring the two associated imports to be updated.

Brief summary of changes if not sufficiently described by commit messages.